### PR TITLE
Lower exit code retry interval to 1 second

### DIFF
--- a/internal/docker/docker_impl.go
+++ b/internal/docker/docker_impl.go
@@ -1090,12 +1090,12 @@ loop:
 		}
 		d.logger.Debug(
 			message.Wrap(lastError,
-				message.EDockerFetchingExitCodeFailed, "Failed to fetch exit code, retrying in 10 seconds"),
+				message.EDockerFetchingExitCodeFailed, "Failed to fetch exit code, retrying in 1 second"),
 		)
 		select {
 		case <-ctx.Done():
 			break loop
-		case <-time.After(10 * time.Second):
+		case <-time.After(1 * time.Second):
 		}
 	}
 	if lastError == nil {


### PR DESCRIPTION
## Please describe the change you are making

Lower the exit code retrieval retry timer from 10 seconds to 1 second.
This fixes (or, at least improves) the following bug:
 1. Login with kerberos auth
 2. write-file is called
 3. Write finishes and the stdin pipe is closed
 4. Docker backend considers one pipe closed = process finishes and tries to get exit 
 5. 4 fails because process is still running
 6. Waits for 10 seconds to retry, connection hangs during that time delaying login.

## Are you the owner of the code you are sending in, or do you have permission of the owner?

Yes

## The code will be published under the MIT-0 license. Have you read and understood this license?

Yes
