### PR TITLE
Fix metadata handling when authz is used

### DIFF
--- a/internal/auth/client_authz.go
+++ b/internal/auth/client_authz.go
@@ -72,7 +72,13 @@ func (client *httpAuthzClient) KeyboardInteractive(
 		return auth
 	}
 
-	return client.processAuthzWithRetry(username, username, connectionID, remoteAddr)
+	authzCtx := client.processAuthzWithRetry(username, username, connectionID, remoteAddr)
+	if !authzCtx.Success() {
+		return authzCtx
+	}
+
+	auth.Metadata().Merge(authzCtx.Metadata())
+	return auth
 }
 
 func (client *httpAuthzClient) Password(
@@ -86,7 +92,13 @@ func (client *httpAuthzClient) Password(
 		return auth
 	}
 
-	return client.processAuthzWithRetry(username, username, connectionID, remoteAddr)
+	authzCtx := client.processAuthzWithRetry(username, username, connectionID, remoteAddr)
+	if !authzCtx.Success() {
+		return authzCtx
+	}
+
+	auth.Metadata().Merge(authzCtx.Metadata())
+	return auth
 }
 
 func (client *httpAuthzClient) PubKey(
@@ -100,7 +112,13 @@ func (client *httpAuthzClient) PubKey(
 		return auth
 	}
 
-	return client.processAuthzWithRetry(username, username, connectionID, remoteAddr)
+	authzCtx := client.processAuthzWithRetry(username, username, connectionID, remoteAddr)
+	if !authzCtx.Success() {
+		return authzCtx
+	}
+
+	auth.Metadata().Merge(authzCtx.Metadata())
+	return auth
 }
 
 func (s *authzContext) AcceptSecContext(token []byte) (outputToken []byte, srcName string, needContinue bool, err error) {


### PR DESCRIPTION
## Please describe the change you are making

Fix bug where when authz is enabled metadata is discarded from the authentication backend in non GSSAPI methods (e.g. password).

## Are you the owner of the code you are sending in, or do you have permission of the owner?

Yes

## The code will be published under the MIT-0 license. Have you read and understood this license?

Yes
