### PR TITLE
Fixed license links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Welcome - and a big thank you for wanting to contribute!
 
-Let's get you started. This project is licensed under the [MIT-0 license](LICENSE.md). This means that the code you submit will be usable for anyone for any purpose free of charge. You should only submit code that you personally own or have permission to submit under this license - and only if you are ok with that.
+Let's get you started. This project is licensed under the [MIT-0 license](LICENSE). This means that the code you submit will be usable for anyone for any purpose free of charge. You should only submit code that you personally own or have permission to submit under this license - and only if you are ok with that.
 
 For the coding aspects, we recommend reading the [development guide](https://containerssh.io/development/). You can also [join our Slack channel](https://join.slack.com/t/containerssh/shared_invite/zt-w2ulatkm-hjGHk8OaxQCBX79XKJHAQQ) to communicate with our community members directly.
 
@@ -10,7 +10,7 @@ For the coding aspects, we recommend reading the [development guide](https://con
 
 Whether you have a big contribution incoming, a small typo fix, or any other type of contribution you would like to add, the process is the same:
 
-1. Make sure you understand the [license](LICENSE.md) and agree to the [Developer Certificate of Origin](DCO.md)
+1. Make sure you understand the [license](LICENSE) and agree to the [Developer Certificate of Origin](DCO.md)
 2. Submit a pull request to the [relevant repository](https://github.com/containerssh)
 3. Wait for a maintainer to review your contribution
 


### PR DESCRIPTION
Signed-off-by: Zhizhen He <hezhizhen.yi@gmail.com>

## Changes introduced with this PR

Please explain your changes here.

The LICENSE file has been renamed `LICENSE` (without `.md` suffix), but its links in `CONTRIBUTING.md` haven't been updated. I fixed the links there.

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/ContainerSSH/community/blob/main/CONTRIBUTING.md).