### PR TITLE
Add Dockerfile to spawn a pull through registry

### DIFF
--- a/internal/test/registry/Dockerfile
+++ b/internal/test/registry/Dockerfile
@@ -1,0 +1,21 @@
+FROM ubuntu:22.04
+
+RUN apt-get update
+RUN apt-get install -y \
+    ca-certificates \
+    curl \
+    gnupg \
+    lsb-release
+RUN mkdir -p /etc/apt/keyrings
+RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+RUN echo \
+    "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
+    $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
+RUN apt-get update
+RUN apt-get install -y \
+    docker-ce \
+    docker-ce-cli \
+    containerd.io \
+    docker-compose-plugin
+
+CMD docker run -v /opt/config.yml:/etc/docker/registry/config.yml -v /opt/htpasswd:/etc/docker/registry/htpasswd -p 5000:5000 --name registry registry:2

--- a/internal/test/registry/opt/config.yml
+++ b/internal/test/registry/opt/config.yml
@@ -1,0 +1,18 @@
+version: 0.1
+log:
+  fields:
+    service: registry
+storage:
+  filesystem:
+    rootdirectory: /var/lib/registry
+    maxthreads: 100
+http:
+  addr: :5000
+  headers:
+    X-Content-Type-Options: [nosniff]
+auth:
+  htpasswd:
+    realm: Registry Realm
+    path: /etc/docker/registry/htpasswd
+proxy:
+  remoteurl: https://registry-1.docker.io

--- a/internal/test/registry/opt/htpasswd
+++ b/internal/test/registry/opt/htpasswd
@@ -1,0 +1,2 @@
+testuser:$2y$05$AChHTEGgUzS/7yR/3V.jweLXoCntAIsliRDIy8MArqOavDhoOA1IW
+


### PR DESCRIPTION
## Changes introduced with this PR

Currently ContainerSSH seems to be not working with private registries. To test this feature and have a simple reproducible way to spawn a registry I created this Dockerfile. The Registry is configured as [pull through cache](https://docs.docker.com/registry/recipes/mirror/).

To get this to work the image has to be build:
`docker build -t example_img .`

The htpasswd file can be generated like this:
`docker run --entrypoint htpasswd httpd:2 -Bbn testuser testpassword > htpasswd`

Since we are building a container within a container we have to pass the `-v /var/run/docker.sock:/var/run/docker.sock` flag to the docker run command:
`docker run -v /var/run/docker.sock:/var/run/docker.sock --name example_container example_img`

The registry should now listen on port 5000 and we can login like this (credentials provided in the htpasswd file):
`docker login http://localhost:5000 --username testuser --password testpassword`

Afterwards we can pull any image like this:
`docker pull localhost:5000/containerssh/containerssh`

Sadly I am not (yet) familiar with how to integrate this as a working test in Github Actions and hope you can make use of this as is. Thanks a lot.

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/ContainerSSH/community/blob/main/CONTRIBUTING.md).