### PR TITLE
Change podConfig to pointer

### DIFF
--- a/internal/kubernetes/kubernetesClientImpl.go
+++ b/internal/kubernetes/kubernetesClientImpl.go
@@ -150,13 +150,13 @@ func (k *kubernetesClientImpl) getPodConfig(
 		podConfig.Spec.Containers[k.config.Pod.ConsoleContainerNumber].Command = k.config.Pod.IdleCommand
 	}
 
-	k.addLabelsToPodConfig(podConfig, labels)
-	k.addAnnotationsToPodConfig(podConfig, annotations)
-	k.addEnvToPodConfig(env, podConfig)
+	k.addLabelsToPodConfig(&podConfig, labels)
+	k.addAnnotationsToPodConfig(&podConfig, annotations)
+	k.addEnvToPodConfig(env, &podConfig)
 	return podConfig, nil
 }
 
-func (k *kubernetesClientImpl) addLabelsToPodConfig(podConfig containerSSHConfig.KubernetesPodConfig, labels map[string]string) {
+func (k *kubernetesClientImpl) addLabelsToPodConfig(podConfig *containerSSHConfig.KubernetesPodConfig, labels map[string]string) {
 	if podConfig.Metadata.Labels == nil {
 		podConfig.Metadata.Labels = map[string]string{}
 	}
@@ -165,7 +165,7 @@ func (k *kubernetesClientImpl) addLabelsToPodConfig(podConfig containerSSHConfig
 	}
 }
 
-func (k *kubernetesClientImpl) addAnnotationsToPodConfig(podConfig containerSSHConfig.KubernetesPodConfig, annotations map[string]string) {
+func (k *kubernetesClientImpl) addAnnotationsToPodConfig(podConfig *containerSSHConfig.KubernetesPodConfig, annotations map[string]string) {
 	if podConfig.Metadata.Annotations == nil {
 		podConfig.Metadata.Annotations = map[string]string{}
 	}
@@ -174,7 +174,7 @@ func (k *kubernetesClientImpl) addAnnotationsToPodConfig(podConfig containerSSHC
 	}
 }
 
-func (k *kubernetesClientImpl) addEnvToPodConfig(env map[string]string, podConfig containerSSHConfig.KubernetesPodConfig) {
+func (k *kubernetesClientImpl) addEnvToPodConfig(env map[string]string, podConfig *containerSSHConfig.KubernetesPodConfig) {
 	for key, value := range env {
 		podConfig.Spec.Containers[k.config.Pod.ConsoleContainerNumber].Env = append(
 			podConfig.Spec.Containers[k.config.Pod.ConsoleContainerNumber].Env,


### PR DESCRIPTION
## Changes introduced with this PR

- Change `podConfig` type from value to pointer.

## Background

I really like this project which enables developers to use containers with SSH protocol. I think this project has lots of potentials.

I found out the actual SSH pods did not have any `labels` & `annotations`(such as `username` and `ip`).
I've looked around and found out the `podConfig` which needs to be changed deeply was instead being copying values.
I changed it to pass as pointer to get the original `podConfig` to be modified.
Please let me know if I mis-understood the code or have better solution.

Thanks again for your awesome work!

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/ContainerSSH/community/blob/main/CONTRIBUTING.md).