### PR TITLE
kubernetes: Fix pod creation fail on long usernames

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -2,7 +2,7 @@ name: Build
 on:
   push:
     branches:
-      - main
+      - '*'
   pull_request:
   schedule:
     - cron: '0 17 * * 2'

--- a/internal/kubernetes/networkHandler.go
+++ b/internal/kubernetes/networkHandler.go
@@ -90,7 +90,7 @@ func (n *networkHandler) OnHandshakeSuccess(meta metadata.ConnectionAuthenticate
 	}
 	n.labels = map[string]string{
 		"containerssh_connection_id": n.connectionID,
-		"containerssh_username":      r.ReplaceAllString(meta.Username, "-"),
+		"containerssh_username":      r.ReplaceAllString(meta.AuthenticatedUsername, "-"),
 	}
 	for authMetadataName, labelName := range n.config.Pod.ExposeAuthMetadataAsLabels {
 		if value, ok := meta.GetMetadata()[authMetadataName]; ok {

--- a/internal/kubernetes/networkHandler.go
+++ b/internal/kubernetes/networkHandler.go
@@ -90,7 +90,16 @@ func (n *networkHandler) OnHandshakeSuccess(meta metadata.ConnectionAuthenticate
 	}
 	n.labels = map[string]string{
 		"containerssh_connection_id": n.connectionID,
-		"containerssh_username":      r.ReplaceAllString(meta.AuthenticatedUsername, "-"),
+	}
+	if len(meta.AuthenticatedUsername) <= 63 {
+		n.labels["containerssh_username"] = r.ReplaceAllString(meta.AuthenticatedUsername, "-")
+	} else {
+		n.logger.Warning(message.NewMessage(
+			message.MKubernetesUsernameTooLong,
+			"The users username (%s) is longer than the 63 character limit of kubernetes labels. The containerssh_username label will be unavailable in the users pod",
+			meta.AuthenticatedUsername,
+		),
+		)
 	}
 	for authMetadataName, labelName := range n.config.Pod.ExposeAuthMetadataAsLabels {
 		if value, ok := meta.GetMetadata()[authMetadataName]; ok {

--- a/message/kubernetes.go
+++ b/message/kubernetes.go
@@ -21,6 +21,10 @@ const MKubernetesPodCreate = "KUBERNETES_POD_CREATE"
 // MKubernetesPodWait indicates that the ContainerSSH Kubernetes module is waiting for the pod to come up.
 const MKubernetesPodWait = "KUBERNETES_POD_WAIT"
 
+// MKubernetesUsernameTooLong indicates that the users username is too long to be provided as a label in the k8s pod.
+// The containerssh_username label is unavailable on that users pod.
+const MKubernetesUsernameTooLong = "KUBERNETES_USERNAME_TOO_LONG"
+
 // MKubernetesPodWaitFailed indicates that the ContainerSSH Kubernetes module failed to wait for the pod to come up.
 // Check the error message for details.
 const MKubernetesPodWaitFailed = "KUBERNETES_POD_WAIT_FAILED"


### PR DESCRIPTION
## Changes introduced with this PR

Kubernetes only allows labels up to 64 characters whereas SSH username can be of any size. If a user logs in with a longer username currently pod creation fails. This PR disables the `containerssh_username` label with longer usernames while printing a relevant warning.

I'll merge this PR in a week unless someone stops me for a review.

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/ContainerSSH/community/blob/main/CONTRIBUTING.md).