### PR TITLE
Fix authorization webhook implementation and add tests

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -87,7 +87,7 @@ jobs:
       - name: Run go test
         run: |
           set -euo pipefail
-          go test -json -p 1 -v ./... 2>&1 | tee /tmp/gotest.log
+          go test -coverprofile=coverage.txt -covermode=atomic -json -p 1 -v ./... 2>&1 | tee /tmp/gotest.log
       - name: Format log output
         if: always()
         run: |
@@ -100,3 +100,7 @@ jobs:
           name: test-log
           path: /tmp/gotest.log
           if-no-files-found: error
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v3
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/config/auth.go
+++ b/config/auth.go
@@ -672,7 +672,7 @@ func (o *AuthGenericConfig) Validate() error {
 type AuthzConfig struct {
 	Method AuthzMethod `json:"method" yaml:"method" default:""`
 
-	AuthWebhookClientConfig `json:",inline" yaml:",inline"`
+	Webhook AuthWebhookClientConfig `json:"webhook" yaml:"webhook"`
 }
 
 // Validate validates the authorization configuration.
@@ -684,7 +684,7 @@ func (k *AuthzConfig) Validate() error {
 	case AuthzMethodDisabled:
 		return nil
 	case AuthzMethodWebhook:
-		return wrap(k.AuthWebhookClientConfig.Validate(), "webhook")
+		return wrap(k.Webhook.Validate(), "webhook")
 	default:
 		return newError("method", "BUG: invalid value for method for authorization: %s", k.Method)
 	}

--- a/internal/auth/authentication_factory.go
+++ b/internal/auth/authentication_factory.go
@@ -114,7 +114,7 @@ func NewAuthorizationProvider(
 	case config.AuthzMethodDisabled:
 		return nil, nil, nil
 	case config.AuthzMethodWebhook:
-		cli, err := NewWebhookClient(AuthenticationTypeAuthz, cfg.AuthWebhookClientConfig, logger, metrics)
+		cli, err := NewWebhookClient(AuthenticationTypeAuthz, cfg.Webhook, logger, metrics)
 		return cli, nil, err
 	default:
 		return nil, nil, fmt.Errorf("unsupported method: %s", cfg.Method)

--- a/internal/auth/webhook_client_impl.go
+++ b/internal/auth/webhook_client_impl.go
@@ -43,7 +43,13 @@ func (client *webhookClient) Authorize(
 		client.logger.Debug(err)
 		return &webhookClientContext{meta.AuthFailed(), false, err}
 	}
-	return client.processAuthzWithRetry(meta)
+
+	url := client.endpoint + "/authz"
+	authzRequest := auth.AuthorizationRequest{
+		ConnectionAuthenticatedMetadata: meta,
+	}
+
+	return client.processAuthzWithRetry(meta, url, authzRequest)
 }
 
 func (client *webhookClient) Password(
@@ -268,10 +274,9 @@ func (client *webhookClient) authServerRequest(endpoint string, requestObject in
 
 func (client *webhookClient) processAuthzWithRetry(
 	meta metadata.ConnectionAuthenticatedMetadata,
+	url string,
+	authzRequest interface{},
 ) AuthenticationContext {
-	url := client.endpoint + "/authz"
-	authzRequest := auth.AuthorizationRequest{}
-
 	ctx, cancel := context.WithTimeout(context.Background(), client.timeout)
 	defer cancel()
 	var lastError error


### PR DESCRIPTION
## Changes introduced with this PR

The authorization webhook had an incomplete implementation leading to it not functioning at all. Additionally, the configuration options were not in line with how it was documented, this PR fixes the webhook and brings the configuration option in line with the existing auth options

Previously:
```yaml
  authz:
    method: webhook
    url: https://myauthenticationserver.example.org
    <webhook options>
```

Now:
```yaml
  authz:
    method: webhook
    webhook: 
      url: https://myauthenticationserver.example.org
      <webhook options>
```

I'll merge this in a weeks time unless someone stops me for a review.

Additionally, add a code coverage job to our CI in order to spot some more blind spots like this.

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/ContainerSSH/community/blob/main/CONTRIBUTING.md).