### PR TITLE
Fix flaky agentprotocol test

### DIFF
--- a/agentprotocol/server_test.go
+++ b/agentprotocol/server_test.go
@@ -95,6 +95,6 @@ func TestConnectionSetup(t *testing.T) {
 		t.Fatalf("Expected to read 'Message to server' instead got %s", string(buf[:nBytes]))
 	}
 	_ = testConClient.Close()
-	close(closeChan)
 	clientCtx.Kill()
+	close(closeChan)
 }


### PR DESCRIPTION
## Changes introduced with this PR

Both testing threads called the Kill() function at the same time which caused them to deadlock as they both were trying to send the termination packet to each-other at the same time. In a real situation this would not cause a deadlock as the communication between the two sides would be buffered.

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/ContainerSSH/community/blob/main/CONTRIBUTING.md).