### PR TITLE
Adds a cleanup webhook called on disconnect and shutdown

### DIFF
--- a/config/appconfig.go
+++ b/config/appconfig.go
@@ -19,6 +19,9 @@ type AppConfig struct {
 	// Auth contains the configuration for user authentication.
 	// swagger:ignore
 	Auth AuthConfig `json:"auth" yaml:"auth"`
+	// CleanupServer contains the settings for fetching the user-specific cleanup webhook.
+	// swagger:ignore
+	CleanupServer HTTPClientConfiguration `json:"cleanupserver" yaml:"cleanupserver"`
 	// Log contains the configuration for the logging level.
 	// swagger:ignore
 	Log LogConfig `json:"log" yaml:"log"`
@@ -119,6 +122,9 @@ func (cfg *AppConfig) Validate(dynamic bool) error {
 	queue.add("geoip", &cfg.GeoIP)
 	queue.add("audit", &cfg.Audit)
 	queue.add("health", &cfg.Health)
+	if cfg.CleanupServer.URL != "" {
+		queue.add("cleanupserver", &cfg.CleanupServer)
+	}
 
 	if cfg.ConfigServer.URL != "" && !dynamic {
 		return queue.Validate()

--- a/message/backend.go
+++ b/message/backend.go
@@ -2,3 +2,6 @@ package message
 
 // EBackendConfig indicates that there is an error in the backend configuration.
 const EBackendConfig = "BACKEND_CONFIG_ERROR"
+
+// ECleanupWebhook indicates that in calling the cleanup webhook
+const ECleanupWebhook = "BACKEND_CLEANUP_WEBHOOK_ERROR"


### PR DESCRIPTION
## Adds a cleanup webhook called on disconnect and shutdown

Thanks for all of your hard work on this project - I'm enjoying it so much I've built a whole project around it to run labs/demos

This PR 
- adds key `cleanupserver` with value HTTPClientConfiguration to the main app config
- converts the configuration to a webhook HTTP client on Backend Handler instantiation
- POSTs to the webhook `OnDisconnect` and `OnShutdown` with the connectionID, expecting a `200` response 
(note that it does not include the username because the Backend Handler does not have the username, presumably because not all backends have usernames, such as the SSH Proxy)

I've been using this code on my own project for a bit now and it's been working great!

Please let me know if you have any questions or would like me to make any changes to this PR as I'm happy to! 

closes #486 

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/ContainerSSH/community/blob/main/CONTRIBUTING.md).